### PR TITLE
Match Note 4 seasonal charging physics

### DIFF
--- a/unlock-effects-test/charging-lock-test-apk/NOTE4_CHARGING_PHYSICS.md
+++ b/unlock-effects-test/charging-lock-test-apk/NOTE4_CHARGING_PHYSICS.md
@@ -1,0 +1,224 @@
+# Note 4 seasonal charging physics
+
+Reference source: Samsung `SystemUI` decompile, classes:
+
+- `ChargingSpringView`
+- `ChargingSummerView`
+- `ChargingAutumnView`
+- `ChargingView` (winter)
+- `ParticleStraightLine`
+
+The stock coordinate system is `360 x 640 dp`. The original code multiplies every
+coordinate by display density (`coefficientX`). The PNGs in this port come from
+`drawable-xxxhdpi`, so bitmap pixels should be converted back to stock dp with a
+`3.0` asset scale.
+
+## Shared battery levels
+
+Spring, summer and autumn use five visible charging frames:
+
+| Battery level | Frame index |
+| --- | --- |
+| `0..25` | `0` |
+| `26..50` | `1` |
+| `51..75` | `2` |
+| `76..99` | `3` |
+| `100` | `4` |
+
+Winter has a separate base image and only four charging overlays:
+
+| Battery level | Winter overlay |
+| --- | --- |
+| `0..25` | none, base only |
+| `26..50` | `winter_charging_25p` |
+| `51..75` | `winter_charging_50p` |
+| `76..99` | `winter_charging_75p` |
+| `100` | `winter_charging_100p` |
+
+## Shared particle animator
+
+`ParticleStraightLine` uses:
+
+- translate X/Y: start to end, `1600 ms`, repeat restart
+- alpha: `1.0 -> 0.0`, `1600 ms`, repeat restart, linear interpolator
+- scale X/Y: current scale to random target, `1600 ms`, repeat restart
+- rotation when enabled: `0 -> 359`, repeat restart
+- start delay: particle index `* 500 ms`
+
+Default Android `ObjectAnimator` interpolator applies to translate, scale and
+rotation unless the stock class explicitly sets another interpolator.
+
+## Spring
+
+Media used by charging:
+
+- frames: `spring_charging_25p`, `spring_charging_50p`,
+  `spring_charging_75p`, `spring_charging_99p`, `spring_charging_100p`
+- particles by slot:
+  `spring_particle_01 x6`, `spring_particle_02 x2`,
+  `spring_particle_03 x4`, `spring_particle_04 x1`
+
+Media not used by spring charging: `flower_01..03`.
+
+Frame motion:
+
+- frame x: `118`
+- frame y: `300 -> 266`
+- y duration: `3300 ms`, repeat reverse
+- rotation: `0 -> 359`, `20010 ms`, repeat restart
+
+Particles:
+
+- count: 13 normally, 12 at full charge (slot 12 is skipped)
+- non-full start: random x in 30%-70% of stock width, y `888`
+- non-full end: x `170`, y `334`
+- full start: x `170`, y `350`
+- full end: random point around x `170`, y `350`, radius `113`
+- rotation: enabled for all spring particle slots, `1600 ms`
+- scale targets:
+  - slots `0..5`: `0.5 + 0.3 * random`
+  - slots `6..7`: `0.7 + 0.3 * random`
+  - slots `8..11`: `0.4 + 0.2 * random`
+  - slot `12`: `0.5 + 0.7 * random`
+
+Z order: particles below charging frame.
+
+## Summer
+
+Media used by charging:
+
+- frames: `summer_charging_01..05`
+- particles by slot:
+  `summer_particle_01 x8`, `summer_particle_02 x1`,
+  `summer_particle_03 x1`
+
+Media not used by summer charging: `unlock_summer_*`.
+
+Frame motion:
+
+- frame x: `118`
+- frame y: `300 -> 266`
+- y duration: `3300 ms`, repeat reverse
+- rotation: `0 -> 359`, `20010 ms`, repeat restart
+
+Particles:
+
+- count: 10 normally
+- full charge: loop returns at slot 8, so only slots `0..7` are visible
+- non-full start: x `170`, y `888`
+- non-full end: random x in 30%-70% of stock width, y `334`
+- full start: x `170`, y `350`
+- full end: random point around x `170`, y `350`, radius `113`, but each
+  axis uses `90 - random(180)` degrees
+- rotation: enabled for all summer particle slots, `1600 ms`
+- scale targets:
+  - slots `0..7`: `0.5 + 0.5 * random`
+  - slot `8`: `0.8 + 0.2 * random`
+  - slot `9`: `1.0 + 0.2 * random`
+
+Z order: particles below charging frame.
+
+## Autumn
+
+Media used by charging:
+
+- frames: `autumn_charging_01..05`
+- full-charge circle: `autumn_charging_circle x4`
+- particles by slot:
+  `autumn_particle_01 x3`, `autumn_particle_02 x1`,
+  `autumn_particle_03 x1`, `autumn_particle_04 x1`
+
+Media not used by autumn charging: `leaf_01..04`, `unlock_autumn_*`.
+
+Frame motion:
+
+- frame x: `114`
+- frame y: `300 -> 266`
+- y duration: `3300 ms`, repeat reverse
+- rotation: `-10 -> 10`, `6670 ms`, repeat reverse
+
+Particles:
+
+- count: 6 normally
+- full charge: no regular particles; only the four circles are animated
+- non-full start: x `170`, y `888`
+- non-full end: random x in 30%-70% of stock width, y `334`
+- rotation: enabled for all autumn particle slots, `1600 ms`
+- scale targets:
+  - slots `0..2`: `0.6 + 0.4 * random`
+  - slots `3..5`: `0.8 + 0.2 * random`
+
+Full-charge circles:
+
+- image: `autumn_charging_circle`
+- count: 4
+- x: `100`
+- y: `264`
+- start delay: circle index `* 1500 ms`
+- alpha: `1.0 -> 0.0`, `4000 ms`, repeat restart,
+  `AccelerateInterpolator`
+- scale X/Y: `1.0 -> 2.2`, `4000 ms`, repeat restart
+
+Z order: particles, circles, charging frame. The decompiled class has a
+`initViewRotateBase()` method, but `initView()` does not call it, so the winter
+base is not part of the stock autumn charging effect.
+
+## Winter
+
+Media used by charging:
+
+- base: `winter_charging_base`
+- frames: `winter_charging_25p`, `winter_charging_50p`,
+  `winter_charging_75p`, `winter_charging_100p`
+- particles weighted by random slot:
+  `winter_particle_01 x3`, `winter_particle_02 x3`,
+  `winter_particle_03 x5`, `winter_particle_04 x1`
+
+Frame/base motion:
+
+- x: `121`
+- base y: `300 -> 267`
+- frame y: `300 -> 266`
+- y duration: `3300 ms`, repeat reverse
+- rotation: `0 -> 359`, `20010 ms`, repeat restart
+
+Particles:
+
+- count: 12
+- stock init chooses `random(12)` for each particle view, then resolves through
+  the weighted slot list above
+- non-full start: x `170`, y `888`
+- non-full end: random x in 30%-70% of stock width, y `334`
+- full start: x `170`, y `350`
+- full end: random point around x `170`, y `350`, radius `113`
+- rotation: enabled for weighted slots `0..10`, disabled for slot `11`
+- rotation duration: `1000 ms`
+- scale targets:
+  - slots `0..2`: `0.6 + 0.8 * random`
+  - slots `3..5`: `0.5 + 0.7 * random`
+  - slots `6..10`: `1.0 + 1.6 * random`
+  - slot `11`: `1.0`
+
+Z order: particles, base, charging frame.
+
+## Corrections for this port
+
+- Use `3.0` as the asset scale for the extracted `drawable-xxxhdpi` PNGs.
+- Remove the custom charging text label from the seasonal doodle view; stock
+  charging effects only draw the seasonal sprites.
+- Do not load or map unlock/touch media into charging physics.
+- Do not include `flower_01..03` or `leaf_01..04` in the charging sprite arrays;
+  those assets are present in the APK, but not referenced by the charging view
+  classes.
+- Keep the autumn circle layer below the autumn charging frame.
+- Keep autumn without `winter_charging_base`; the method exists in the
+  decompiled class, but it is not called for autumn.
+- Generate particle endpoints and target scales once per season/full-state
+  change, then reuse those values while drawing. This mirrors the stock
+  `animationViewParticle()` behavior: values are random, but always inside the
+  same Samsung ranges and not recomputed every frame.
+- Winter should preserve Samsung's weighted random sprite selection: each
+  particle view chooses `random(12)` over the stock weighted slot list
+  (`01 x3`, `02 x3`, `03 x5`, `04 x1`). Those sprite slots stay stable while
+  winter regenerates endpoints/scales for full/non-full transitions. Slot `11`
+  is the only non-rotating winter particle.

--- a/unlock-effects-test/charging-lock-test-apk/src/com/codex/charginglocktest/SeasonalDoodleView.java
+++ b/unlock-effects-test/charging-lock-test-apk/src/com/codex/charginglocktest/SeasonalDoodleView.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.os.SystemClock;
@@ -13,6 +12,7 @@ import android.view.View;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Calendar;
+import java.util.Random;
 
 public class SeasonalDoodleView extends View {
     static final int SEASON_AUTO = -1;
@@ -25,7 +25,7 @@ public class SeasonalDoodleView extends View {
     private static final long SEASONAL_CHARGE_PERCENT_STEP_MS = 200L;
     private static final float STOCK_CHARGE_BASE_WIDTH = 360f;
     private static final float STOCK_CHARGE_BASE_HEIGHT = 640f;
-    private static final float STOCK_CHARGE_ASSET_SCALE = 4f;
+    private static final float STOCK_CHARGE_ASSET_SCALE = 3f;
     private static final float STOCK_TALL_SCREEN_VERTICAL_BIAS = 0.24f;
     private static final long STOCK_CHARGE_MOVE_DURATION_MS = 3300L;
     private static final long STOCK_CHARGE_ROTATE_DURATION_MS = 20010L;
@@ -34,6 +34,9 @@ public class SeasonalDoodleView extends View {
     private static final int[] SPRING_PARTICLE_SPRITE_INDEX = {
             5, 5, 5, 5, 5, 5, 6, 6, 7, 7, 7, 7, 8
     };
+    private static final int[] WINTER_PARTICLE_RANDOM_SLOT_TO_SPRITE_ID = {
+            0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 3
+    };
 
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG | Paint.DITHER_FLAG);
     private final Matrix matrix = new Matrix();
@@ -41,12 +44,18 @@ public class SeasonalDoodleView extends View {
     private final Bitmap[] summerSprites;
     private final Bitmap[] autumnSprites;
     private final Bitmap[] winterSprites;
+    private final Random particleRandom = new Random();
+    private final ParticleSpec[] particleSpecs = new ParticleSpec[SPRING_PARTICLE_SPRITE_INDEX.length];
+    private final int[] winterParticleRandomSlots = new int[12];
     private long chargeStartedAt = SystemClock.uptimeMillis();
+    private int particleSpecTheme = Integer.MIN_VALUE;
     private int seasonMode = SEASON_AUTO;
     private int positionOffsetX;
     private int positionOffsetY;
     private int batteryPercent;
     private boolean debugRollingCharge;
+    private boolean particleSpecFull;
+    private boolean winterParticleSlotsReady;
 
     public SeasonalDoodleView(Context context) {
         super(context);
@@ -67,6 +76,7 @@ public class SeasonalDoodleView extends View {
 
     void resetChargeCycle() {
         chargeStartedAt = SystemClock.uptimeMillis();
+        invalidateParticleSpecs();
         invalidate();
     }
 
@@ -136,23 +146,11 @@ public class SeasonalDoodleView extends View {
         float scale = stockChargeScale();
         float left = stockChargeLeft(scale);
         float top = stockChargeTop(scale);
-        drawChargeStatus(canvas, percent, scale, left, top);
         if (theme == SEASON_SPRING) {
             drawSamsungSpringCharge(canvas, elapsed, percent, scale, left, top, sprites);
             return;
         }
         drawSamsungSeasonCharge(canvas, theme, elapsed, percent, scale, left, top, sprites);
-    }
-
-    private void drawChargeStatus(Canvas canvas, int percent, float scale, float left, float top) {
-        paint.setStyle(Paint.Style.FILL);
-        paint.setShader(null);
-        paint.setFakeBoldText(false);
-        paint.setTextAlign(Paint.Align.CENTER);
-        paint.setTextSize(14f * scale);
-        paint.setColor(Color.argb(230, 250, 255, 255));
-        canvas.drawText(seasonalChargeStatus(percent), stockX(180f, scale, left), stockY(238f, scale, top), paint);
-        paint.setTextAlign(Paint.Align.LEFT);
     }
 
     private void drawSamsungSpringCharge(Canvas canvas, long elapsed, int percent, float scale, float left, float top, Bitmap[] sprites) {
@@ -169,10 +167,11 @@ public class SeasonalDoodleView extends View {
     }
 
     private void drawSamsungSpringParticles(Canvas canvas, long elapsed, int frameIndex, float scale, float left, float top, Bitmap[] sprites) {
+        ensureParticleSpecs(SEASON_SPRING, frameIndex == 4);
         int count = frameIndex == 4 ? SPRING_PARTICLE_SPRITE_INDEX.length - 1 : SPRING_PARTICLE_SPRITE_INDEX.length;
         for (int i = 0; i < count; i++) {
-            int spriteIndex = SPRING_PARTICLE_SPRITE_INDEX[i];
-            if (spriteIndex >= sprites.length || sprites[spriteIndex] == null) {
+            ParticleSpec spec = particleSpecs[i];
+            if (spec == null || spec.spriteIndex >= sprites.length || sprites[spec.spriteIndex] == null) {
                 continue;
             }
             long local = elapsed - i * SPRING_PARTICLE_DELAY_MS;
@@ -181,26 +180,9 @@ public class SeasonalDoodleView extends View {
             }
             float raw = (local % SPRING_PARTICLE_DURATION_MS) / (float) SPRING_PARTICLE_DURATION_MS;
             float eased = accelerateDecelerate(raw);
-            float startX;
-            float startY;
-            float endX;
-            float endY;
-            if (frameIndex == 4) {
-                float angleX = stableInt(i, 11, 359) * (float) Math.PI / 180f;
-                float angleY = stableInt(i, 12, 359) * (float) Math.PI / 180f;
-                startX = 170f;
-                startY = 350f;
-                endX = 170f + 113f * (float) Math.sin(angleX);
-                endY = 350f - 113f * (float) Math.cos(angleY);
-            } else {
-                startX = 108f + stableInt(i, 1, 144);
-                startY = 888f;
-                endX = 170f;
-                endY = 334f;
-            }
-            drawStockBitmapTopLeft(canvas, sprites[spriteIndex], scale, left, top,
-                    lerp(startX, endX, eased), lerp(startY, endY, eased),
-                    1f - raw, 359f * eased, springParticleScale(i, eased));
+            drawStockBitmapTopLeft(canvas, sprites[spec.spriteIndex], scale, left, top,
+                    lerp(spec.startX, spec.endX, eased), lerp(spec.startY, spec.endY, eased),
+                    1f - raw, 359f * eased, lerp(1f, spec.targetScale, eased));
         }
     }
 
@@ -211,13 +193,15 @@ public class SeasonalDoodleView extends View {
         float baseX = seasonChargeTopLeftX(theme);
         float baseFrameY = lerp(300f, 267f, accelerateDecelerate(reverseRepeatPhase(elapsed, STOCK_CHARGE_MOVE_DURATION_MS)));
         float frameY = lerp(300f, 266f, accelerateDecelerate(reverseRepeatPhase(elapsed, STOCK_CHARGE_MOVE_DURATION_MS)));
-        Bitmap base = theme == SEASON_WINTER && winterSprites != null && winterSprites.length > 0 ? winterSprites[0] : null;
-        if (theme == SEASON_WINTER && base != null) {
-            drawStockBitmapTopLeft(canvas, base, scale, left, top, baseX, baseFrameY, 1f,
-                    seasonChargeRotation(theme, elapsed, true), 1f);
-        }
         if (theme == SEASON_AUTUMN && frameIndex == 4) {
             drawAutumnChargeCircles(canvas, elapsed, scale, left, top, sprites);
+        }
+        Bitmap base = theme == SEASON_WINTER && winterSprites != null && winterSprites.length > 0
+                ? winterSprites[0]
+                : null;
+        if (base != null) {
+            drawStockBitmapTopLeft(canvas, base, scale, left, top, baseX, baseFrameY, 1f,
+                    seasonChargeRotation(theme, elapsed, true), 1f);
         }
 
         Bitmap frame = seasonalChargeFrameBitmap(theme, sprites, frameIndex);
@@ -228,10 +212,11 @@ public class SeasonalDoodleView extends View {
     }
 
     private void drawSamsungSeasonParticles(Canvas canvas, int theme, long elapsed, int frameIndex, float scale, float left, float top, Bitmap[] sprites) {
+        ensureParticleSpecs(theme, frameIndex == 4);
         int count = seasonParticleCount(theme, frameIndex);
         for (int i = 0; i < count; i++) {
-            int spriteIndex = seasonParticleSpriteIndex(theme, i);
-            if (spriteIndex < 0 || sprites == null || spriteIndex >= sprites.length || sprites[spriteIndex] == null) {
+            ParticleSpec spec = particleSpecs[i];
+            if (spec == null || spec.spriteIndex < 0 || sprites == null || spec.spriteIndex >= sprites.length || sprites[spec.spriteIndex] == null) {
                 continue;
             }
             long local = elapsed - i * SPRING_PARTICLE_DELAY_MS;
@@ -240,36 +225,12 @@ public class SeasonalDoodleView extends View {
             }
             float raw = (local % SPRING_PARTICLE_DURATION_MS) / (float) SPRING_PARTICLE_DURATION_MS;
             float eased = accelerateDecelerate(raw);
-            float startX;
-            float startY;
-            float endX;
-            float endY;
-            if (frameIndex == 4 && theme != SEASON_AUTUMN) {
-                startX = 170f;
-                startY = 350f;
-                if (theme == SEASON_SUMMER) {
-                    float angleX = (90f - stableInt(i, 21, 180)) * (float) Math.PI / 180f;
-                    float angleY = (90f - stableInt(i, 22, 180)) * (float) Math.PI / 180f;
-                    endX = 170f + 113f * (float) Math.sin(angleX);
-                    endY = 350f - 113f * (float) Math.cos(angleY);
-                } else {
-                    float angleX = stableInt(i, 23, 359) * (float) Math.PI / 180f;
-                    float angleY = stableInt(i, 24, 359) * (float) Math.PI / 180f;
-                    endX = 170f + 113f * (float) Math.sin(angleX);
-                    endY = 350f - 113f * (float) Math.cos(angleY);
-                }
-            } else {
-                startX = 170f;
-                startY = 888f;
-                endX = 108f + stableInt(i, 25 + theme, 144);
-                endY = 334f;
-            }
-            float rotation = seasonParticleRotates(theme, i)
-                    ? 359f * accelerateDecelerate((local % seasonParticleRotateDuration(theme)) / (float) seasonParticleRotateDuration(theme))
+            float rotation = spec.rotate
+                    ? 359f * accelerateDecelerate((local % spec.rotateDuration) / (float) spec.rotateDuration)
                     : 0f;
-            drawStockBitmapTopLeft(canvas, sprites[spriteIndex], scale, left, top,
-                    lerp(startX, endX, eased), lerp(startY, endY, eased),
-                    1f - raw, rotation, seasonParticleScale(theme, i, eased));
+            drawStockBitmapTopLeft(canvas, sprites[spec.spriteIndex], scale, left, top,
+                    lerp(spec.startX, spec.endX, eased), lerp(spec.startY, spec.endY, eased),
+                    1f - raw, rotation, lerp(1f, spec.targetScale, eased));
         }
     }
 
@@ -329,7 +290,87 @@ public class SeasonalDoodleView extends View {
         return 0;
     }
 
-    private int seasonParticleSpriteIndex(int theme, int index) {
+    private void invalidateParticleSpecs() {
+        particleSpecTheme = Integer.MIN_VALUE;
+        winterParticleSlotsReady = false;
+    }
+
+    private void ensureParticleSpecs(int theme, boolean full) {
+        if (particleSpecTheme == theme && particleSpecFull == full) {
+            return;
+        }
+        boolean themeChanged = particleSpecTheme != theme;
+        for (int i = 0; i < particleSpecs.length; i++) {
+            particleSpecs[i] = null;
+        }
+        if (themeChanged && theme == SEASON_WINTER) {
+            winterParticleSlotsReady = false;
+        }
+        if (theme == SEASON_WINTER) {
+            ensureWinterParticleSlots();
+        }
+        int count = theme == SEASON_SPRING
+                ? full ? SPRING_PARTICLE_SPRITE_INDEX.length - 1 : SPRING_PARTICLE_SPRITE_INDEX.length
+                : seasonParticleCount(theme, full ? 4 : 0);
+        for (int i = 0; i < count; i++) {
+            particleSpecs[i] = createParticleSpec(theme, i, full);
+        }
+        particleSpecTheme = theme;
+        particleSpecFull = full;
+    }
+
+    private void ensureWinterParticleSlots() {
+        if (winterParticleSlotsReady) {
+            return;
+        }
+        for (int i = 0; i < winterParticleRandomSlots.length; i++) {
+            winterParticleRandomSlots[i] = particleRandom.nextInt(WINTER_PARTICLE_RANDOM_SLOT_TO_SPRITE_ID.length);
+        }
+        winterParticleSlotsReady = true;
+    }
+
+    private ParticleSpec createParticleSpec(int theme, int index, boolean full) {
+        ParticleSpec spec = new ParticleSpec();
+        spec.spriteIndex = particleSpriteIndex(theme, index);
+        spec.rotate = theme != SEASON_WINTER || winterParticleRandomSlots[index] < 11;
+        spec.rotateDuration = theme == SEASON_WINTER ? 1000L : SPRING_PARTICLE_DURATION_MS;
+        spec.targetScale = particleTargetScale(theme, index);
+        if (full && theme != SEASON_AUTUMN) {
+            spec.startX = 170f;
+            spec.startY = 350f;
+            if (theme == SEASON_SUMMER) {
+                float angleX = (90f - particleRandom.nextInt(180)) * (float) Math.PI / 180f;
+                float angleY = (90f - particleRandom.nextInt(180)) * (float) Math.PI / 180f;
+                spec.endX = 170f + 113f * (float) Math.sin(angleX);
+                spec.endY = 350f - 113f * (float) Math.cos(angleY);
+            } else {
+                float angleX = particleRandom.nextInt(359) * (float) Math.PI / 180f;
+                float angleY = particleRandom.nextInt(359) * (float) Math.PI / 180f;
+                spec.endX = 170f + 113f * (float) Math.sin(angleX);
+                spec.endY = 350f - 113f * (float) Math.cos(angleY);
+            }
+        } else if (theme == SEASON_SPRING) {
+            spec.startX = randomStockParticleX();
+            spec.startY = 888f;
+            spec.endX = 170f;
+            spec.endY = 334f;
+        } else {
+            spec.startX = 170f;
+            spec.startY = 888f;
+            spec.endX = randomStockParticleX();
+            spec.endY = 334f;
+        }
+        return spec;
+    }
+
+    private float randomStockParticleX() {
+        return 108f + 144f * particleRandom.nextFloat();
+    }
+
+    private int particleSpriteIndex(int theme, int index) {
+        if (theme == SEASON_SPRING) {
+            return SPRING_PARTICLE_SPRITE_INDEX[index];
+        }
         if (theme == SEASON_SUMMER) {
             return index < 8 ? 5 : index == 8 ? 6 : 7;
         }
@@ -337,43 +378,42 @@ public class SeasonalDoodleView extends View {
             return index < 3 ? 6 : index == 3 ? 7 : index == 4 ? 8 : 9;
         }
         if (theme == SEASON_WINTER) {
-            int[] ids = {0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 3};
-            return 5 + ids[stableInt(index, 31, ids.length)];
+            return 5 + WINTER_PARTICLE_RANDOM_SLOT_TO_SPRITE_ID[winterParticleRandomSlots[index]];
         }
         return -1;
     }
 
-    private float seasonParticleScale(int theme, int index, float eased) {
-        float random = stableUnit(index, 41 + theme);
-        float target = 1f;
+    private float particleTargetScale(int theme, int index) {
+        float random = particleRandom.nextFloat();
         if (theme == SEASON_SUMMER) {
-            target = index < 8 ? 0.5f + 0.5f * random : index == 8 ? 0.8f + 0.2f * random : 1f + 0.2f * random;
-        } else if (theme == SEASON_AUTUMN) {
-            target = index < 3 ? 0.6f + 0.4f * random : 0.8f + 0.2f * random;
-        } else if (theme == SEASON_WINTER) {
-            int[] ids = {0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 3};
-            int id = ids[stableInt(index, 31, ids.length)];
-            if (id == 0) {
-                target = 0.6f + 0.8f * random;
-            } else if (id == 1) {
-                target = 0.5f + 0.7f * random;
-            } else if (id == 2) {
-                target = 1f + 1.6f * random;
-            }
+            return index < 8 ? 0.5f + 0.5f * random : index == 8 ? 0.8f + 0.2f * random : 1f + 0.2f * random;
         }
-        return lerp(1f, target, eased);
-    }
-
-    private boolean seasonParticleRotates(int theme, int index) {
+        if (theme == SEASON_AUTUMN) {
+            return index < 3 ? 0.6f + 0.4f * random : 0.8f + 0.2f * random;
+        }
         if (theme == SEASON_WINTER) {
-            int[] ids = {0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 3};
-            return ids[stableInt(index, 31, ids.length)] < 3;
+            int slot = winterParticleRandomSlots[index];
+            if (slot < 3) {
+                return 0.6f + 0.8f * random;
+            }
+            if (slot < 6) {
+                return 0.5f + 0.7f * random;
+            }
+            if (slot < 11) {
+                return 1f + 1.6f * random;
+            }
+            return 1f;
         }
-        return true;
-    }
-
-    private long seasonParticleRotateDuration(int theme) {
-        return theme == SEASON_WINTER ? 1000L : SPRING_PARTICLE_DURATION_MS;
+        if (index < 6) {
+            return 0.5f + 0.3f * random;
+        }
+        if (index < 8) {
+            return 0.7f + 0.3f * random;
+        }
+        if (index < 12) {
+            return 0.4f + 0.2f * random;
+        }
+        return 0.5f + 0.7f * random;
     }
 
     private int seasonalChargeFrameIndex(int percent) {
@@ -417,35 +457,6 @@ public class SeasonalDoodleView extends View {
 
     private float stockY(float y, float scale, float top) {
         return top + y * scale;
-    }
-
-    private float springParticleScale(int index, float eased) {
-        float random = stableUnit(index, 2);
-        float target;
-        if (index < 6) {
-            target = 0.5f + 0.3f * random;
-        } else if (index < 8) {
-            target = 0.7f + 0.3f * random;
-        } else if (index < 12) {
-            target = 0.4f + 0.2f * random;
-        } else {
-            target = 0.5f + 0.7f * random;
-        }
-        return lerp(1f, target, eased);
-    }
-
-    private float stableUnit(int index, int salt) {
-        int value = 0x45d9f3b ^ (index * 0x1f123bb5) ^ (salt * 0x6c8e9cf5);
-        value ^= value >>> 16;
-        value *= 0x7feb352d;
-        value ^= value >>> 15;
-        value *= 0x846ca68b;
-        value ^= value >>> 16;
-        return (value & 0x00ffffff) / (float) 0x01000000;
-    }
-
-    private int stableInt(int index, int salt, int bound) {
-        return Math.max(0, Math.min(bound - 1, (int) (stableUnit(index, salt) * bound)));
     }
 
     private float accelerateDecelerate(float input) {
@@ -497,8 +508,15 @@ public class SeasonalDoodleView extends View {
         }
     }
 
-    private String seasonalChargeStatus(int percent) {
-        return percent >= 100 ? "Charged" : "Charging, " + percent + "%";
+    private static final class ParticleSpec {
+        int spriteIndex;
+        float startX;
+        float startY;
+        float endX;
+        float endY;
+        float targetScale;
+        boolean rotate;
+        long rotateDuration;
     }
 
     private Bitmap[] loadSprites(String[] names) {
@@ -538,12 +556,7 @@ public class SeasonalDoodleView extends View {
                         "note4seasonal/charging/spring_charging_99p.png",
                         "note4seasonal/charging/spring_charging_100p.png"
                 },
-                numberedAssetNames("note4seasonal/charging/spring_particle_", 1, 4, 2, ".png"),
-                new String[] {
-                        "note4seasonal/charging/flower_01.png",
-                        "note4seasonal/charging/flower_02.png",
-                        "note4seasonal/charging/flower_03.png"
-                });
+                numberedAssetNames("note4seasonal/charging/spring_particle_", 1, 4, 2, ".png"));
     }
 
     private static String[] note4ChargeSummerNames() {
@@ -566,13 +579,7 @@ public class SeasonalDoodleView extends View {
                         "note4seasonal/charging/autumn_charging_05.png",
                         "note4seasonal/charging/autumn_charging_circle.png"
                 },
-                numberedAssetNames("note4seasonal/charging/autumn_particle_", 1, 4, 2, ".png"),
-                new String[] {
-                        "note4seasonal/charging/leaf_01.png",
-                        "note4seasonal/charging/leaf_02.png",
-                        "note4seasonal/charging/leaf_03.png",
-                        "note4seasonal/charging/leaf_04.png"
-                });
+                numberedAssetNames("note4seasonal/charging/autumn_particle_", 1, 4, 2, ".png"));
     }
 
     private static String[] note4ChargeWinterNames() {


### PR DESCRIPTION
## Summary

- document the original Note 4 seasonal charging effect physics and media mapping from the Samsung SystemUI decompile
- align the charging doodle asset scale with the extracted xxxhdpi PNGs
- remove non-stock charging text and keep unlock/extra media out of charging sprite arrays
- generate particle endpoints/scales once per stock full/non-full state using Samsung ranges instead of deterministic per-frame approximations
- preserve winter's weighted random particle selection and non-rotating slot behavior

## Notes

This does not try to reproduce Samsung's exact random values, because the original code uses runtime `new Random()` without a fixed seed. It mirrors the stock stochastic behavior by using the same ranges, counts, sprite mappings, durations, and full/non-full regeneration points.

## Verification

- `git diff --check`
- APK build intentionally not regenerated for this PR.